### PR TITLE
Use translate="no" placeholder

### DIFF
--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     'autotranslate',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/tests/test_project/urls.py
+++ b/tests/test_project/urls.py
@@ -14,9 +14,12 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import url
 from django.contrib import admin
+try:
+    from django.urls import path
+except ImportError:  # older django
+    from django.conf.urls import url
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     dj{111}-py{27,34,35,36}
     dj{20}-py{34,35,36}
     dj{21}-py{35,36,37}
+    dj{41}-py{38}
 skipsdist = True
 
 [testenv]
@@ -25,6 +26,7 @@ deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj41: Django>=4.1,<4.2
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
 usedevelop = True


### PR DESCRIPTION
Instead of converting to __item__ which google may translate, can use <span translate="no"> placeholder to fully prevent translation, at the same time we want to keep the newlines within the translations as some of the translated text were markdown and newlines are important.